### PR TITLE
Handle when the current context is undefined

### DIFF
--- a/lib/opencensus/plug/trace.ex
+++ b/lib/opencensus/plug/trace.ex
@@ -112,13 +112,19 @@ defmodule Opencensus.Plug.Trace do
       :ocp.with_span_ctx(ctx)
     end
 
-    encoded =
-      :ocp.current_span_ctx()
-      |> :oc_span_ctx_header.encode()
-      |> :erlang.iolist_to_binary()
+    case :ocp.current_span_ctx() do
+      :undefined ->
+        conn
 
-    Logger.metadata(tracespan: encoded)
+      ctx ->
+        encoded =
+          ctx
+          |> :oc_span_ctx_header.encode()
+          |> :erlang.iolist_to_binary()
 
-    Plug.Conn.put_resp_header(conn, header, encoded)
+        Logger.metadata(tracespan: encoded)
+
+        Plug.Conn.put_resp_header(conn, header, encoded)
+    end
   end
 end


### PR DESCRIPTION
This could either happen if the HTTP server or the incoming request header sets no context. 

This manifested in our test suite where the context was never set, and so evaluated to `:undefined`.