### PR TITLE
Fix Dialyzer warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,6 +12,7 @@ defmodule Opencensus.Plug.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       test_coverage: [tool: ExCoveralls],
+      dialyzer: [flags: ["-Wunmatched_returns", :error_handling, :race_conditions, :underspecs]],
       preferred_cli_env: [
         coveralls: :test,
         "coveralls.html": :test,


### PR DESCRIPTION
This involves refactoring Opencensus.Plug.Trace to move some code out of quote (to make it exposed to Dialyzer) and adding some warnings to Dialyzer config (those were the default until Dialyxir 0.4).

An alternative would be to not refactor the module, but instead create a dummy one somewhere in `test/` that uses this module and triggers Dialyzer errors. However given that there is [a Credo check that discourages long quote blocks](https://github.com/rrrene/credo/blob/cea1ac63dc378316f5e6dd050165a00e5b20ca2f/lib/credo/check/refactor/long_quote_blocks.ex), the approach proposed in this PR may have an additional benefit.